### PR TITLE
Website: fix markdown formatting for list

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,3 +1,6 @@
+---
+output: github_document
+---
 
 ```{r, setup, echo = FALSE, message = FALSE}
 knitr::opts_chunk$set(
@@ -15,6 +18,7 @@ knitr::opts_chunk$set(
 # prettyunits
 
 The `prettyunits` package formats quantities in human readable form.
+
 * Time intervals: '1337000' -> '15d 11h 23m 20s'.
 * Vague time intervals: '2674000' -> 'about a month ago'.
 * Bytes: '1337' -> '1.34 kB'.


### PR DESCRIPTION
Note that on Windows I didn't have `info$uname` and `info$grname` for the example in the README, so you would have to regenerate README.md yourself I guess.

Before:

![image](https://github.com/r-lib/prettyunits/assets/52219252/bae5cd71-1136-4c91-90fe-e69c2391572f)

After:

![image](https://github.com/r-lib/prettyunits/assets/52219252/f66feaaa-7557-43b3-8a67-ed84e9b806eb)
